### PR TITLE
Add msmtp as email package and supply symbolic links for configuration

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -8,8 +8,12 @@ ARG APPRISE_VERSION=0.8.5
 RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         cron \
+        msmtp msmtp-mta \
         python3-pip python3-setuptools && \
     pip3 install --no-cache-dir --upgrade apprise==${APPRISE_VERSION} && \
+# aim msmtp configuration files to outer config directory
+    ln -s /config/app/msmtprc /etc/msmtprc \
+    ln -s /config/app/aliases /etc/aliases \
 # clean up
     apt purge -y python3-pip python3-setuptools && \
     apt autoremove -y && \

--- a/linux-arm.Dockerfile
+++ b/linux-arm.Dockerfile
@@ -8,8 +8,12 @@ ARG APPRISE_VERSION=0.8.5
 RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         cron \
+        msmtp msmtp-mta \
         python3-pip python3-setuptools && \
     pip3 install --no-cache-dir --upgrade apprise==${APPRISE_VERSION} && \
+# aim msmtp configuration files to outer config directory
+    ln -s /config/app/msmtprc /etc/msmtprc \
+    ln -s /config/app/aliases /etc/aliases \
 # clean up
     apt purge -y python3-pip python3-setuptools && \
     apt autoremove -y && \

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -8,8 +8,12 @@ ARG APPRISE_VERSION=0.8.5
 RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         cron \
+        msmtp msmtp-mta \
         python3-pip python3-setuptools && \
     pip3 install --no-cache-dir --upgrade apprise==${APPRISE_VERSION} && \
+# aim msmtp configuration files to outer config directory
+    ln -s /config/app/msmtprc /etc/msmtprc \
+    ln -s /config/app/aliases /etc/aliases \
 # clean up
     apt purge -y python3-pip python3-setuptools && \
     apt autoremove -y && \


### PR DESCRIPTION
Hello!
This pull request adds the package - [msmtp](https://marlam.de/msmtp/) to the docker image. It contains an MTA with the emulated sendmail command in about 1.4MB. 
This enables cron to send output of the executed tasks to a configured email account.
As a result, the backup process can be monitored.
The documentation change is contained in separate pull request.
Best regards
Sönke